### PR TITLE
render function does not extend create's option

### DIFF
--- a/index.js
+++ b/index.js
@@ -289,8 +289,6 @@ var create = function(opts) {
         url        : url
       }, sopts);
 
-      console.log('ropts', ropts)
-
       ropts.maxRenders = opts.maxRenders;
       ropts.filename = _getTmpFile(opts.tmp,ropts.format);
       ropts.id = id;

--- a/index.js
+++ b/index.js
@@ -284,14 +284,13 @@ var create = function(opts) {
     var proxy = queued[id] = duplexify();
 
     var initialize = function (url) {
+      sopts = xtend(opts, ropts)
       ropts = xtend({
-        url        : url,
-        quality:opts.quality,
-        format     : opts.format,
-        printMedia : opts.printMedia,
-        expects    : opts.expects,
-        timeout    : opts.timeout
-      }, ropts);
+        url        : url
+      }, sopts);
+
+      console.log('ropts', ropts)
+
       ropts.maxRenders = opts.maxRenders;
       ropts.filename = _getTmpFile(opts.tmp,ropts.format);
       ropts.id = id;


### PR DESCRIPTION
When we create new phantom object with options, these options were not being taken into render's initialize function. Thus, setting margin and many other option were simply ignored.
