### PR TITLE
Allow for Header/Footer in PDF rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ Obviously, make sure the path './includes/my-date-polyfill.js' is resolvable fro
 When the page is [initialized](http://phantomjs.org/api/webpage/handler/on-initialized.html), any scripts you listed there will
 be injected before any rendering happens.
 
+## Header and footer (PDF Only)
+For PDF Files only - Header and Footer can be added by adding a global ``PhantomJSPrinting`` object to the html you are rendering.
+Example:
+
+```
+<script type="text/javascript">
+  var PhantomJSPrinting = {
+    header: {
+      height: "1cm",
+      contents: function(pageNum, numPages) { return pageNum + "/" + numPages; }
+    },
+    footer: {
+      height: "1cm",
+      contents: function(pageNum, numPages) { return pageNum + "/" + numPages; }
+    }
+  };
+</script>
+```
 
 ## Extra Dependencies
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ldjson-stream": "^1.1.0",
     "mkdirp": "^0.5.0",
     "once": "^1.3.0",
-    "phantomjs": "1.9.x",
+    "phantomjs": "2.1.1",
     "thunky": "^0.1.0",
     "xtend": "^3.0.0",
     "duplexify": "~3.2.0",


### PR DESCRIPTION
As shown in the PhantomJS example - https://github.com/ariya/phantomjs/blob/master/examples/printheaderfooter.js
