### PR TITLE
Add zoomFactor and dpi settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var render = phantom({
   quality     : 100,         // The default image quality. Defaults to 100. Only relevant for jpeg format.
   width       : 1280,        // Changes the width size. Defaults to 1280
   height      : 800,         // Changes the height size. Defaults to 960
+  zoomFactor  : 1.5,         // Changes the scaling factor. Defaults to 1
   paperFormat : 'A4',        // Defaults to A4. Also supported: 'A3', 'A4', 'A5', 'Legal', 'Letter', 'Tabloid'.
   orientation : 'portrait',  // Defaults to portrait. 'landscape' is also valid
   margin      : '0cm',       // Defaults to 0cm. Supported dimension units are: 'mm', 'cm', 'in', 'px'. No unit means 'px'.

--- a/phantom-process.js
+++ b/phantom-process.js
@@ -161,6 +161,10 @@ var loop = function() {
       margin: line.margin || '0cm'
     };
 
+  if (line.zoomFactor) page.zoomFactor = line.zoomFactor;
+
+  if (line.dpi) page.settings.dpi = line.dpi;
+
   if (line.userAgent) page.settings.userAgent = line.userAgent;
 
   if (line.headers) page.customHeaders = line.headers;


### PR DESCRIPTION
This PR adds support for phantomjs's [zoomFactor](http://phantomjs.org/api/webpage/property/zoom-factor.html) setting.

In the next phantomjs version, [dpi](https://github.com/ariya/phantomjs/commit/5232c9dff98115600d1b1491e538e01c0de2d650) will be supported in [settings](http://phantomjs.org/api/webpage/property/settings.html), I think it makes sense to already include it but not document it yet.
