### PR TITLE
Update inseure debug/debug-stream packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "repository": "e-conomic/phantom-render-stream",
   "dependencies": {
     "after-all": "~1.0.0",
-    "debug": "^1.0.2",
-    "debug-stream": "^2.0.1",
+    "debug": "^2.2.0",
+    "debug-stream": "^3.0.1",
     "fwd-stream": "^1.0.4",
     "hat": "0.0.3",
     "ldjson-stream": "^1.1.0",


### PR DESCRIPTION
`debug` and `debug-stream` rely on the `ms` package, which has a ReDOS vulnerability in versions <0.7.1 (https://nodesecurity.io/advisories/46).

Upgrading `debug` and `debug-stream` resolves this.
